### PR TITLE
Nmt v1.3better

### DIFF
--- a/macapype/pipelines/register.py
+++ b/macapype/pipelines/register.py
@@ -310,6 +310,13 @@ def create_register_NMT_pipe(params_template, params={},
         niu.IdentityInterface(fields=['T1', 'indiv_params']),
         name='inputnode')
 
+
+    if "NMT_version" in params.keys():
+        NMT_version = params['NMT_version']
+
+        print("*** Overriding NMT_version with parmas {}".format(
+            params['NMT_version']))
+
     # N4 intensity normalization over brain
     norm_intensity = NodeParams(ants.N4BiasFieldCorrection(),
                                 params=parse_key(params, "norm_intensity"),

--- a/macapype/utils/data_test_servers.json
+++ b/macapype/utils/data_test_servers.json
@@ -15,6 +15,7 @@
             "NMT_v1.2.hemi": "SMPYKkrpiP8XrFT",
             "NMT_v1.3": "qmBSE4prcXYLE94",
             "NMT_v2.0_asym": "wBxS65AHSpRGXsR",
+            "NMT_v1.3better": "as88XXQJmoaHYKa",
             "NMT_FSL": "ajAtB7qgaPAmKyJ",
             "inia19": "WZo9wZdreTMwfQA",
             "marmotemplate": "5xzm7DJD9kB99gG",
@@ -31,6 +32,7 @@
             "data_test_macaque": "RDxdxzmX89xcABG",
             "data_test_sphinx_macaque": "RkWbC2gmbn4ytK3",
             "NMT_v1.2": "5YnwNf3Jr7Qsc8H",
+            "NMT_v1.3better": "6DBctypBT7LsexL",
             "Juna_Chimp": "bwcqjKc9GXpn9yS",
             "MBM_v3.0.1": "RMxXifHeigNkB3g"
                     },

--- a/macapype/utils/templates.json
+++ b/macapype/utils/templates.json
@@ -33,6 +33,15 @@
         "LR_hemi_template": "supplemental_masks/NMT_LR_brainmask.nii.gz",
         "cereb_template": "supplemental_masks/NMT_cerebellum_mask.nii.gz"
     },
+    "NMT_v1.3better":
+    {
+        "template_head": "NMT.nii.gz",
+        "template_brain": "NMT_SS.nii.gz",
+
+        "template_gm": "NMT_seg_gm_better.nii.gz",
+        "template_wm": "NMT_seg_wm_better.nii.gz",
+        "template_csf": "NMT_seg_csf_better.nii.gz"
+    },
     "NMT_v2.0_asym_05mm":
     {
         "template_head": "NMT_v2.0_asym_05mm.nii.gz",


### PR DESCRIPTION
Modified NMT v1.3 with a split of _segmentation_4classes that were available sofar -> gm_better, wm_better, csf_better, etc and added the possibility of overwrite NMT_version in params 