### PR TITLE
Keep gcc by indexes

### DIFF
--- a/macapype/nodes/surface.py
+++ b/macapype/nodes/surface.py
@@ -14,6 +14,7 @@ def getLargestCC(segmentation):
     largestCC = labels == np.argmax(np.bincount(labels.flat)[1:])+1
     return largestCC, labels
 
+
 def keep_gcc(nii_file):
     import os
     import nibabel as nib
@@ -53,7 +54,6 @@ def keep_gcc(nii_file):
     return gcc_nii_file
 
 
-
 def keep_gcc_by_index(nii_file):
     import os
     import nibabel as nib
@@ -77,8 +77,8 @@ def keep_gcc_by_index(nii_file):
         data_data_bin_index[data == index] = 1
 
         if np.sum(data_data_bin_index):
-            gcc_index_data, labels_index_data = getLargestCC(data_data_bin_index)
-            new_data[gcc_index_data == True] = index
+            gcc_index_data, _ = getLargestCC(data_data_bin_index)
+            new_data[gcc_index_data] = index
 
     # nibabel (np.array -> nifti)
     new_img = nib.Nifti1Image(dataobj=new_data,
@@ -90,6 +90,7 @@ def keep_gcc_by_index(nii_file):
     nib.save(new_img, gcc_nii_file)
 
     return gcc_nii_file
+
 
 def merge_tissues(dseg_file, keep_indexes):
 

--- a/macapype/nodes/surface.py
+++ b/macapype/nodes/surface.py
@@ -66,6 +66,8 @@ def keep_gcc_by_index(nii_file):
     img = nib.load(nii_file)
     data = img.get_fdata().astype(np.int16)
 
+    path, fname, ext = split_f(nii_file)
+
     print(np.unique(data))
 
     new_data = np.zeros(data.shape, data.dtype)

--- a/macapype/nodes/surface.py
+++ b/macapype/nodes/surface.py
@@ -7,6 +7,7 @@ from nipype.interfaces.afni.base import AFNICommandBase
 def getLargestCC(segmentation):
 
     from skimage.measure import label
+    import numpy as np
 
     labels = label(segmentation)
     assert labels.max() != 0  # assume at least 1 CC

--- a/macapype/nodes/surface.py
+++ b/macapype/nodes/surface.py
@@ -75,7 +75,7 @@ def keep_gcc_by_index(nii_file):
         data_data_bin_index[data == index] = 1
 
         if np.sum(data_data_bin_index):
-            gcc_index_data, = getLargestCC(data_data_bin_index)
+            gcc_index_data, labels_index_data = getLargestCC(data_data_bin_index)
             new_data[gcc_index_data == True] = index
 
     # nibabel (np.array -> nifti)

--- a/macapype/nodes/surface.py
+++ b/macapype/nodes/surface.py
@@ -19,6 +19,8 @@ def keep_gcc(nii_file):
     import numpy as np
     from nipype.utils.filemanip import split_filename as split_f
 
+    from macapype.nodes.surface import getLargestCC
+
     # nibabel (nifti -> np.array)
     img = nib.load(nii_file)
     data = img.get_fdata().astype(np.int16)
@@ -56,6 +58,8 @@ def keep_gcc_by_index(nii_file):
     import nibabel as nib
     import numpy as np
     from nipype.utils.filemanip import split_filename as split_f
+
+    from macapype.nodes.surface import getLargestCC
 
     # nibabel (nifti -> np.array)
     img = nib.load(nii_file)

--- a/macapype/nodes/surface.py
+++ b/macapype/nodes/surface.py
@@ -71,8 +71,11 @@ def keep_gcc_by_index(nii_file):
 
     for index in np.unique(data)[1:]:
         data_data_bin_index = np.zeros(data.shape, data.dtype)
-        gcc_index_data, = getLargestCC(data_data_bin_index)
-        new_data[gcc_index_data == True] = index
+        data_data_bin_index[data == index] = 1
+
+        if np.sum(data_data_bin_index):
+            gcc_index_data, = getLargestCC(data_data_bin_index)
+            new_data[gcc_index_data == True] = index
 
     # nibabel (np.array -> nifti)
     new_img = nib.Nifti1Image(dataobj=new_data,

--- a/macapype/pipelines/surface.py
+++ b/macapype/pipelines/surface.py
@@ -705,7 +705,6 @@ def create_IsoSurface_brain_pipe(params={},
             fields=["segmented_file"]),
         name='inputnode')
 
-
     # keep_gcc_mask
     keep_gcc_mask = pe.Node(
         interface=niu.Function(input_names=["nii_file"],
@@ -715,7 +714,6 @@ def create_IsoSurface_brain_pipe(params={},
 
     IsoSurface_brain_pipe.connect(inputnode, 'segmented_file',
                                   keep_gcc_mask, "nii_file")
-
 
     # merge_brain_tissues
     merge_brain_tissues = NodeParams(

--- a/macapype/pipelines/surface.py
+++ b/macapype/pipelines/surface.py
@@ -725,7 +725,7 @@ def create_IsoSurface_brain_pipe(params={},
         params=parse_key(params, "merge_brain_tissues"),
         name="keep_GCC_brain")
 
-    IsoSurface_brain_pipe.connect(keep_gcc_mask, "gcc_nii_file")
+    IsoSurface_brain_pipe.connect(keep_gcc_mask, "gcc_nii_file",
                                   merge_brain_tissues, 'dseg_file')
 
     # keep_gcc_bin_mask

--- a/macapype/pipelines/surface.py
+++ b/macapype/pipelines/surface.py
@@ -11,7 +11,8 @@ import macapype.nodes.register as reg
 from macapype.nodes.surface import (Meshify, split_LR_mask,
                                     wrap_nii2mesh,
                                     IsoSurface, merge_tissues,
-                                    keep_gcc)
+                                    keep_gcc,
+                                    keep_gcc_by_index)
 
 from macapype.utils.utils_nodes import parse_key, NodeParams
 
@@ -704,6 +705,18 @@ def create_IsoSurface_brain_pipe(params={},
             fields=["segmented_file"]),
         name='inputnode')
 
+
+    # keep_gcc_mask
+    keep_gcc_mask = pe.Node(
+        interface=niu.Function(input_names=["nii_file"],
+                               output_names=["gcc_nii_file"],
+                               function=keep_gcc_by_index),
+        name="keep_gcc_mask")
+
+    IsoSurface_brain_pipe.connect(inputnode, 'segmented_file',
+                                  keep_gcc_mask, "nii_file")
+
+
     # merge_brain_tissues
     merge_brain_tissues = NodeParams(
         interface=niu.Function(input_names=["dseg_file", "keep_indexes"],
@@ -712,7 +725,7 @@ def create_IsoSurface_brain_pipe(params={},
         params=parse_key(params, "merge_brain_tissues"),
         name="keep_GCC_brain")
 
-    IsoSurface_brain_pipe.connect(inputnode, 'segmented_file',
+    IsoSurface_brain_pipe.connect(keep_gcc_mask, "gcc_nii_file")
                                   merge_brain_tissues, 'dseg_file')
 
     # keep_gcc_bin_mask


### PR DESCRIPTION
allow to get rid off external (disconnected) components by tissues